### PR TITLE
Fixes Seti icons misalignment

### DIFF
--- a/styles/styles.less
+++ b/styles/styles.less
@@ -1,0 +1,1 @@
+.smart-tab-names { display: inline-block }


### PR DESCRIPTION
When using `seti-icons`, the `smart-tab-names` element got in the middle of the flow causing this UI glitch

![image](https://cloud.githubusercontent.com/assets/140042/19722311/5ac2e260-9b76-11e6-9796-bf3ce81313e1.png)

Setting it to `inline-block` solves the issue.
